### PR TITLE
Add user management endpoints with audit logging

### DIFF
--- a/Azorian.Tests/Azorian.Tests.csproj
+++ b/Azorian.Tests/Azorian.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0-preview.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Azorian.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Azorian.Tests/UsersControllerTests.cs
+++ b/Azorian.Tests/UsersControllerTests.cs
@@ -1,0 +1,95 @@
+using Azorian.Controllers;
+using Azorian.Data;
+using Azorian.Models;
+using Azorian.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+public class UsersControllerTests
+{
+    private static AzorianContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AzorianContext>()
+            .UseInMemoryDatabase(databaseName: System.Guid.NewGuid().ToString())
+            .Options;
+        return new AzorianContext(options);
+    }
+
+    [Fact]
+    public async Task CRUD_Workflow_CreatesAuditLogs()
+    {
+        using var context = CreateContext();
+        var service = new UserService(context);
+        var controller = new UsersController(service);
+
+        // Create
+        var createResult = await controller.CreateUser(new User { Name = "Alice" });
+        var created = Assert.IsType<CreatedAtActionResult>(createResult.Result);
+        var createdUser = Assert.IsType<User>(created.Value);
+        Assert.Equal("Alice", createdUser.Name);
+        Assert.Single(context.Users);
+        Assert.Single(context.AuditLogs);
+        Assert.Equal("CreateUser", context.AuditLogs.Single().Action);
+
+        // Update
+        var updatedUser = new User { Id = createdUser.Id, Name = "Alice Updated" };
+        var updateResult = await controller.UpdateUser(createdUser.Id, updatedUser);
+        var ok = Assert.IsType<OkObjectResult>(updateResult.Result);
+        var returned = Assert.IsType<User>(ok.Value);
+        Assert.Equal("Alice Updated", returned.Name);
+        Assert.Equal(2, context.AuditLogs.Count());
+        Assert.Contains(context.AuditLogs, l => l.Action == "UpdateUser");
+
+        // Delete
+        var deleteResult = await controller.DeleteUser(createdUser.Id);
+        Assert.IsType<NoContentResult>(deleteResult);
+        Assert.Empty(context.Users);
+        Assert.Equal(3, context.AuditLogs.Count());
+        Assert.Contains(context.AuditLogs, l => l.Action == "DeleteUser");
+    }
+
+    [Fact]
+    public void WriteEndpoints_HaveAuthorizeAdminRole()
+    {
+        var type = typeof(UsersController);
+        foreach (var method in new[] { "CreateUser", "UpdateUser", "DeleteUser" })
+        {
+            var mi = type.GetMethod(method);
+            var attr = Assert.Single(mi!.GetCustomAttributes(typeof(AuthorizeAttribute), false));
+            var auth = Assert.IsType<AuthorizeAttribute>(attr);
+            Assert.Equal("Admin", auth.Roles);
+        }
+
+        foreach (var method in new[] { "GetUsers", "GetUser" })
+        {
+            var mi = type.GetMethod(method);
+            var attrs = mi!.GetCustomAttributes(typeof(AuthorizeAttribute), false);
+            Assert.True(attrs.Length == 0 || attrs.Cast<AuthorizeAttribute>().All(a => a.Roles != "Admin"));
+        }
+    }
+
+    [Fact]
+    public async Task GetEndpoints_ReturnUsers()
+    {
+        using var context = CreateContext();
+        context.Users.Add(new User { Name = "Bob" });
+        await context.SaveChangesAsync();
+        var service = new UserService(context);
+        var controller = new UsersController(service);
+
+        var listResult = await controller.GetUsers();
+        var listOk = Assert.IsType<OkObjectResult>(listResult.Result);
+        var users = Assert.IsAssignableFrom<IEnumerable<User>>(listOk.Value);
+        Assert.Single(users);
+
+        var singleResult = await controller.GetUser(context.Users.Single().Id);
+        var singleOk = Assert.IsType<OkObjectResult>(singleResult.Result);
+        var user = Assert.IsType<User>(singleOk.Value);
+        Assert.Equal("Bob", user.Name);
+    }
+}

--- a/Azorian.csproj
+++ b/Azorian.csproj
@@ -20,10 +20,16 @@
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0-preview.3" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Models\" />
-      <Folder Include="Services\" />
-      <Folder Include="Data\" />
-    </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Models\" />
+    <Folder Include="Services\" />
+    <Folder Include="Data\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Azorian.Tests/**" />
+    <EmbeddedResource Remove="Azorian.Tests/**" />
+    <None Remove="Azorian.Tests/**" />
+  </ItemGroup>
 
 </Project>

--- a/Azorian.sln
+++ b/Azorian.sln
@@ -7,15 +7,44 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		compose.yaml = compose.yaml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azorian.Tests", "Azorian.Tests\Azorian.Tests.csproj", "{A49FB505-2169-42FA-A4FA-CEDFA80BDFEA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A6C336A9-0504-49CF-B207-D353020B3673}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A6C336A9-0504-49CF-B207-D353020B3673}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6C336A9-0504-49CF-B207-D353020B3673}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A6C336A9-0504-49CF-B207-D353020B3673}.Debug|x64.Build.0 = Debug|Any CPU
+		{A6C336A9-0504-49CF-B207-D353020B3673}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A6C336A9-0504-49CF-B207-D353020B3673}.Debug|x86.Build.0 = Debug|Any CPU
 		{A6C336A9-0504-49CF-B207-D353020B3673}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A6C336A9-0504-49CF-B207-D353020B3673}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A6C336A9-0504-49CF-B207-D353020B3673}.Release|x64.ActiveCfg = Release|Any CPU
+		{A6C336A9-0504-49CF-B207-D353020B3673}.Release|x64.Build.0 = Release|Any CPU
+		{A6C336A9-0504-49CF-B207-D353020B3673}.Release|x86.ActiveCfg = Release|Any CPU
+		{A6C336A9-0504-49CF-B207-D353020B3673}.Release|x86.Build.0 = Release|Any CPU
+		{A49FB505-2169-42FA-A4FA-CEDFA80BDFEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A49FB505-2169-42FA-A4FA-CEDFA80BDFEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A49FB505-2169-42FA-A4FA-CEDFA80BDFEA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A49FB505-2169-42FA-A4FA-CEDFA80BDFEA}.Debug|x64.Build.0 = Debug|Any CPU
+		{A49FB505-2169-42FA-A4FA-CEDFA80BDFEA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A49FB505-2169-42FA-A4FA-CEDFA80BDFEA}.Debug|x86.Build.0 = Debug|Any CPU
+		{A49FB505-2169-42FA-A4FA-CEDFA80BDFEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A49FB505-2169-42FA-A4FA-CEDFA80BDFEA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A49FB505-2169-42FA-A4FA-CEDFA80BDFEA}.Release|x64.ActiveCfg = Release|Any CPU
+		{A49FB505-2169-42FA-A4FA-CEDFA80BDFEA}.Release|x64.Build.0 = Release|Any CPU
+		{A49FB505-2169-42FA-A4FA-CEDFA80BDFEA}.Release|x86.ActiveCfg = Release|Any CPU
+		{A49FB505-2169-42FA-A4FA-CEDFA80BDFEA}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/Controllers/UsersController.cs
+++ b/Controllers/UsersController.cs
@@ -1,6 +1,7 @@
 using Azorian.Models;
 using Azorian.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Azorian.Controllers;
 
@@ -47,9 +48,38 @@ public class UsersController : ControllerBase
     /// Creates a new user without any roles.
     /// </summary>
     [HttpPost]
+    [Authorize(Roles = "Admin")]
     public async Task<ActionResult<User>> CreateUser(User user)
     {
-        var created = await _userService.CreateUserAsync(user);
+        var created = await _userService.CreateUserAsync(user, null); // Replace null with authenticated user id when auth is implemented
         return CreatedAtAction(nameof(GetUser), new { id = created.Id }, created);
+    }
+
+    /// <summary>
+    /// Updates an existing user. Admin only.
+    /// </summary>
+    [HttpPut("{id}")]
+    [Authorize(Roles = "Admin")]
+    public async Task<ActionResult<User>> UpdateUser(int id, User user)
+    {
+        if (id != user.Id)
+            return BadRequest();
+        var updated = await _userService.UpdateUserAsync(user, null);
+        if (updated == null)
+            return NotFound();
+        return Ok(updated);
+    }
+
+    /// <summary>
+    /// Deletes a user. Admin only.
+    /// </summary>
+    [HttpDelete("{id}")]
+    [Authorize(Roles = "Admin")]
+    public async Task<IActionResult> DeleteUser(int id)
+    {
+        var result = await _userService.DeleteUserAsync(id, null);
+        if (!result)
+            return NotFound();
+        return NoContent();
     }
 }

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -1,6 +1,8 @@
+using System;
 using Azorian.Data;
 using Azorian.Models;
 using Microsoft.EntityFrameworkCore;
+
 
 namespace Azorian.Services;
 
@@ -32,10 +34,52 @@ public class UserService
     /// <summary>
     /// Creates a new user without any roles.
     /// </summary>
-    public async Task<User> CreateUserAsync(User user)
+    public async Task<User> CreateUserAsync(User user, int? performedByUserId = null)
     {
         _context.Users.Add(user);
         await _context.SaveChangesAsync();
+        await LogAsync("CreateUser", user.Id, performedByUserId);
         return user;
+    }
+
+    /// <summary>
+    /// Updates an existing user.
+    /// </summary>
+    public async Task<User?> UpdateUserAsync(User user, int? performedByUserId = null)
+    {
+        var existing = await _context.Users.FindAsync(user.Id);
+        if (existing == null)
+            return null;
+
+        existing.Name = user.Name;
+        await _context.SaveChangesAsync();
+        await LogAsync("UpdateUser", existing.Id, performedByUserId);
+        return existing;
+    }
+
+    /// <summary>
+    /// Deletes a user.
+    /// </summary>
+    public async Task<bool> DeleteUserAsync(int id, int? performedByUserId = null)
+    {
+        var user = await _context.Users.FindAsync(id);
+        if (user == null)
+            return false;
+        _context.Users.Remove(user);
+        await _context.SaveChangesAsync();
+        await LogAsync("DeleteUser", id, performedByUserId);
+        return true;
+    }
+
+    private async Task LogAsync(string action, int? targetUserId, int? performedByUserId)
+    {
+        _context.AuditLogs.Add(new AuditLog
+        {
+            Action = action,
+            TargetUserId = targetUserId,
+            PerformedByUserId = performedByUserId,
+            Timestamp = DateTime.UtcNow
+        });
+        await _context.SaveChangesAsync();
     }
 }


### PR DESCRIPTION
## Summary
- restore update and delete user endpoints with admin-only access
- add audit logging for user create, update, and delete actions
- cover user endpoint behavior and authorization with new tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c607450f40832b9d1407c214425403