### PR TITLE
Add class entity and relationships

### DIFF
--- a/Data/AppDBContext.cs
+++ b/Data/AppDBContext.cs
@@ -12,6 +12,7 @@ namespace Azorian.Data
         public DbSet<Schoolhouse> Schoolhouses { get; set; }
         public DbSet<SchoolhouseStaff> SchoolhouseStaff { get; set; }
         public DbSet<InstructorProfile> InstructorProfiles { get; set; }
+        public DbSet<Class> Classes { get; set; }
 
         public DbSet<MediaAsset> MediaAssets { get; set; }
         public DbSet<SchoolhouseMedia> SchoolhouseMedia { get; set; }

--- a/Data/Entities/Class.cs
+++ b/Data/Entities/Class.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Azorian.Data
+{
+    public class Class
+    {
+        public Guid Id { get; set; }
+        public Guid SchoolhouseId { get; set; }
+        public string Title { get; set; }
+        public string Slug { get; set; }
+        public string Summary { get; set; }
+        public decimal PricePerSeat { get; set; }
+        public DateTime StartDateTimeUtc { get; set; }
+        public DateTime? EndDateTimeUtc { get; set; }
+        public bool IsPublished { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime? UpdatedAt { get; set; }
+
+        public Schoolhouse Schoolhouse { get; set; }
+        public ICollection<ClassMedia> Media { get; set; }
+    }
+
+    public class ClassConfiguration : IEntityTypeConfiguration<Class>
+    {
+        public void Configure(EntityTypeBuilder<Class> entity)
+        {
+            entity.HasKey(e => e.Id);
+
+            entity.Property(e => e.Title)
+                .IsRequired()
+                .HasMaxLength(200);
+
+            entity.Property(e => e.Slug)
+                .IsRequired()
+                .HasMaxLength(200);
+
+            entity.Property(e => e.Summary)
+                .HasMaxLength(2000);
+
+            entity.Property(e => e.PricePerSeat)
+                .HasColumnType("decimal(18,2)");
+
+            entity.HasIndex(e => new { e.SchoolhouseId, e.Slug })
+                .IsUnique();
+
+            entity.HasOne(e => e.Schoolhouse)
+                .WithMany(s => s.Classes)
+                .HasForeignKey(e => e.SchoolhouseId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/Data/Entities/ClassMedia.cs
+++ b/Data/Entities/ClassMedia.cs
@@ -15,6 +15,7 @@ namespace Azorian.Data
         public DateTime CreatedAt { get; set; }
         public DateTime? UpdatedAt { get; set; }
 
+        public Class Class { get; set; }
         public MediaAsset MediaAsset { get; set; }
     }
 
@@ -23,6 +24,11 @@ namespace Azorian.Data
         public void Configure(EntityTypeBuilder<ClassMedia> entity)
         {
             entity.HasKey(e => e.Id);
+
+            entity.HasOne(e => e.Class)
+                .WithMany(c => c.Media)
+                .HasForeignKey(e => e.ClassId)
+                .OnDelete(DeleteBehavior.Cascade);
 
             entity.HasOne(e => e.MediaAsset)
                 .WithMany(m => m.ClassMedia)

--- a/Data/Entities/Schoolhouse.cs
+++ b/Data/Entities/Schoolhouse.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -31,6 +32,7 @@ namespace Azorian.Data
 
         public ICollection<SchoolhouseStaff> Staff { get; set; }
         public ICollection<SchoolhouseMedia> Media { get; set; }
+        public ICollection<Class> Classes { get; set; }
 
     }
 


### PR DESCRIPTION
## Summary
- add a Class aggregate with publishing, scheduling, and pricing fields
- attach Class collections to Schoolhouse and update ClassMedia to reference Class entities
- register the Classes DbSet so EF Core can query and persist classes

## Testing
- not run (dotnet not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ff69ff67c832ba7264e965174d812)