### PR TITLE
Add domain services for schoolhouse staff and media management

### DIFF
--- a/Domain/DTOs/UploadMediaDto.cs
+++ b/Domain/DTOs/UploadMediaDto.cs
@@ -1,0 +1,16 @@
+using System;
+using Azorian.Data;
+
+namespace Azorian.Domain.DTOs
+{
+    public class UploadMediaDto
+    {
+        public MediaType MediaType { get; set; }
+        public string StoragePath { get; set; }
+        public string FileName { get; set; }
+        public long FileSizeBytes { get; set; }
+        public string MimeType { get; set; }
+        public string Title { get; set; }
+        public string Description { get; set; }
+    }
+}

--- a/Domain/Services/IMediaService.cs
+++ b/Domain/Services/IMediaService.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azorian.Domain.DTOs;
+using Azorian.Data;
+
+namespace Azorian.Domain.Services
+{
+    public interface IMediaService
+    {
+        Task<MediaAsset> UploadMediaAsset(Guid ownerUserId, UploadMediaDto dto, CancellationToken ct);
+        Task AttachMediaToInstructor(Guid instructorProfileId, Guid mediaAssetId, Guid actingUserId, CancellationToken ct);
+        Task AttachMediaToSchoolhouse(Guid schoolhouseId, Guid mediaAssetId, Guid actingUserId, bool isVisibleOnPublicSite, CancellationToken ct);
+        Task AttachMediaToClass(Guid classId, Guid mediaAssetId, Guid actingUserId, bool isVisibleToPublic, bool isVisibleToEnrolledOnly, CancellationToken ct);
+    }
+}

--- a/Domain/Services/ISchoolhouseStaffService.cs
+++ b/Domain/Services/ISchoolhouseStaffService.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azorian.Domain.Services
+{
+    public interface ISchoolhouseStaffService
+    {
+        Task AddAdminToSchoolhouse(Guid schoolhouseId, Guid userId, Guid actingUserId, CancellationToken ct);
+        Task AddInstructorToSchoolhouse(Guid schoolhouseId, Guid userId, Guid actingUserId, CancellationToken ct);
+        Task RemoveStaffFromSchoolhouse(Guid schoolhouseId, Guid userId, Guid actingUserId, CancellationToken ct);
+    }
+}

--- a/Services/MediaService.cs
+++ b/Services/MediaService.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azorian.Data;
+using Azorian.Domain.DTOs;
+using Azorian.Domain.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace Azorian.Services
+{
+    public class MediaService : IMediaService
+    {
+        private readonly AppDbContext _dbContext;
+
+        public MediaService(AppDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        public async Task<MediaAsset> UploadMediaAsset(Guid ownerUserId, UploadMediaDto dto, CancellationToken ct)
+        {
+            await EnsureUserExists(ownerUserId, ct);
+            var now = DateTime.UtcNow;
+            var mediaAsset = new MediaAsset
+            {
+                Id = Guid.NewGuid(),
+                OwnerUserId = ownerUserId,
+                MediaType = dto.MediaType,
+                StoragePath = dto.StoragePath,
+                FileName = dto.FileName,
+                FileSizeBytes = dto.FileSizeBytes,
+                MimeType = dto.MimeType,
+                Title = dto.Title,
+                Description = dto.Description,
+                CreatedAt = now
+            };
+
+            await _dbContext.MediaAssets.AddAsync(mediaAsset, ct);
+            await _dbContext.SaveChangesAsync(ct);
+            return mediaAsset;
+        }
+
+        public async Task AttachMediaToInstructor(Guid instructorProfileId, Guid mediaAssetId, Guid actingUserId, CancellationToken ct)
+        {
+            var profile = await _dbContext.InstructorProfiles.FirstOrDefaultAsync(p => p.Id == instructorProfileId, ct);
+            if (profile == null)
+            {
+                throw new InvalidOperationException("Instructor profile not found.");
+            }
+
+            if (profile.UserId != actingUserId)
+            {
+                throw new InvalidOperationException("Acting user is not authorized to manage this instructor profile.");
+            }
+
+            var mediaAsset = await _dbContext.MediaAssets.FirstOrDefaultAsync(m => m.Id == mediaAssetId, ct);
+            if (mediaAsset == null)
+            {
+                throw new InvalidOperationException("Media asset not found.");
+            }
+
+            if (mediaAsset.OwnerUserId != actingUserId)
+            {
+                throw new InvalidOperationException("Media asset must be owned by the acting user.");
+            }
+
+            var exists = await _dbContext.InstructorMedia.AsNoTracking().AnyAsync(im => im.InstructorProfileId == instructorProfileId && im.MediaAssetId == mediaAssetId, ct);
+            if (exists)
+            {
+                return;
+            }
+
+            var instructorMedia = new InstructorMedia
+            {
+                Id = Guid.NewGuid(),
+                InstructorProfileId = instructorProfileId,
+                MediaAssetId = mediaAssetId,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            await _dbContext.InstructorMedia.AddAsync(instructorMedia, ct);
+            await _dbContext.SaveChangesAsync(ct);
+        }
+
+        public async Task AttachMediaToSchoolhouse(Guid schoolhouseId, Guid mediaAssetId, Guid actingUserId, bool isVisibleOnPublicSite, CancellationToken ct)
+        {
+            await EnsureActingUserCanManageSchoolhouseMedia(schoolhouseId, actingUserId, ct);
+            var mediaAsset = await _dbContext.MediaAssets.FirstOrDefaultAsync(m => m.Id == mediaAssetId, ct);
+            if (mediaAsset == null)
+            {
+                throw new InvalidOperationException("Media asset not found.");
+            }
+
+            var exists = await _dbContext.SchoolhouseMedia.AsNoTracking().AnyAsync(sm => sm.SchoolhouseId == schoolhouseId && sm.MediaAssetId == mediaAssetId, ct);
+            if (exists)
+            {
+                return;
+            }
+
+            var schoolhouseMedia = new SchoolhouseMedia
+            {
+                Id = Guid.NewGuid(),
+                SchoolhouseId = schoolhouseId,
+                MediaAssetId = mediaAssetId,
+                IsVisibleOnPublicSite = isVisibleOnPublicSite,
+                SortOrder = 0,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            await _dbContext.SchoolhouseMedia.AddAsync(schoolhouseMedia, ct);
+            await _dbContext.SaveChangesAsync(ct);
+        }
+
+        public async Task AttachMediaToClass(Guid classId, Guid mediaAssetId, Guid actingUserId, bool isVisibleToPublic, bool isVisibleToEnrolledOnly, CancellationToken ct)
+        {
+            var classEntity = await _dbContext.Classes.AsNoTracking().FirstOrDefaultAsync(c => c.Id == classId, ct);
+            if (classEntity == null)
+            {
+                throw new InvalidOperationException("Class not found.");
+            }
+
+            await EnsureActingUserCanManageSchoolhouseMedia(classEntity.SchoolhouseId, actingUserId, ct);
+            var mediaAsset = await _dbContext.MediaAssets.FirstOrDefaultAsync(m => m.Id == mediaAssetId, ct);
+            if (mediaAsset == null)
+            {
+                throw new InvalidOperationException("Media asset not found.");
+            }
+
+            var exists = await _dbContext.ClassMedia.AsNoTracking().AnyAsync(cm => cm.ClassId == classId && cm.MediaAssetId == mediaAssetId, ct);
+            if (exists)
+            {
+                return;
+            }
+
+            var classMedia = new ClassMedia
+            {
+                Id = Guid.NewGuid(),
+                ClassId = classId,
+                MediaAssetId = mediaAssetId,
+                IsVisibleToPublic = isVisibleToPublic,
+                IsVisibleToEnrolledOnly = isVisibleToEnrolledOnly,
+                SortOrder = 0,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            await _dbContext.ClassMedia.AddAsync(classMedia, ct);
+            await _dbContext.SaveChangesAsync(ct);
+        }
+
+        private async Task EnsureUserExists(Guid userId, CancellationToken ct)
+        {
+            var exists = await _dbContext.Users.AsNoTracking().AnyAsync(u => u.Id == userId, ct);
+            if (!exists)
+            {
+                throw new InvalidOperationException("User does not exist.");
+            }
+        }
+
+        private async Task EnsureActingUserCanManageSchoolhouseMedia(Guid schoolhouseId, Guid actingUserId, CancellationToken ct)
+        {
+            var authorized = await _dbContext.SchoolhouseStaff
+                .AsNoTracking()
+                .AnyAsync(s => s.SchoolhouseId == schoolhouseId && s.UserId == actingUserId && s.IsActive && (s.StaffRole == StaffRole.Owner || s.StaffRole == StaffRole.Admin), ct);
+            if (!authorized)
+            {
+                throw new InvalidOperationException("Acting user is not authorized to manage media for this schoolhouse.");
+            }
+        }
+    }
+}

--- a/Services/SchoolhouseStaffService.cs
+++ b/Services/SchoolhouseStaffService.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azorian.Data;
+using Azorian.Domain.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace Azorian.Services
+{
+    public class SchoolhouseStaffService : ISchoolhouseStaffService
+    {
+        private readonly AppDbContext _dbContext;
+
+        public SchoolhouseStaffService(AppDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        public async Task AddAdminToSchoolhouse(Guid schoolhouseId, Guid userId, Guid actingUserId, CancellationToken ct)
+        {
+            await EnsureActingUserCanManageStaff(schoolhouseId, actingUserId, ct);
+            await EnsureUserExists(userId, ct);
+            await SetStaffRole(schoolhouseId, userId, StaffRole.Admin, ct);
+        }
+
+        public async Task AddInstructorToSchoolhouse(Guid schoolhouseId, Guid userId, Guid actingUserId, CancellationToken ct)
+        {
+            await EnsureActingUserCanManageStaff(schoolhouseId, actingUserId, ct);
+            await EnsureInstructorProfileExists(userId, ct);
+            await SetStaffRole(schoolhouseId, userId, StaffRole.Instructor, ct);
+        }
+
+        public async Task RemoveStaffFromSchoolhouse(Guid schoolhouseId, Guid userId, Guid actingUserId, CancellationToken ct)
+        {
+            await EnsureActingUserCanManageStaff(schoolhouseId, actingUserId, ct);
+            var staff = await _dbContext.SchoolhouseStaff.FirstOrDefaultAsync(s => s.SchoolhouseId == schoolhouseId && s.UserId == userId, ct);
+            if (staff == null)
+            {
+                throw new InvalidOperationException("Staff member not found for the specified schoolhouse.");
+            }
+
+            if (staff.StaffRole == StaffRole.Owner)
+            {
+                throw new InvalidOperationException("Owners cannot be removed from the schoolhouse.");
+            }
+
+            var now = DateTime.UtcNow;
+            staff.IsActive = false;
+            staff.UpdatedAt = now;
+
+            if (staff.StaffRole == StaffRole.Instructor)
+            {
+                var mediaToRemove = await _dbContext.SchoolhouseMedia
+                    .Include(sm => sm.MediaAsset)
+                    .Where(sm => sm.SchoolhouseId == schoolhouseId && sm.MediaAsset.OwnerUserId == userId)
+                    .ToListAsync(ct);
+                _dbContext.SchoolhouseMedia.RemoveRange(mediaToRemove);
+            }
+
+            await _dbContext.SaveChangesAsync(ct);
+        }
+
+        private async Task EnsureActingUserCanManageStaff(Guid schoolhouseId, Guid actingUserId, CancellationToken ct)
+        {
+            var authorized = await _dbContext.SchoolhouseStaff
+                .AsNoTracking()
+                .AnyAsync(s => s.SchoolhouseId == schoolhouseId && s.UserId == actingUserId && s.IsActive && (s.StaffRole == StaffRole.Owner || s.StaffRole == StaffRole.Admin), ct);
+            if (!authorized)
+            {
+                throw new InvalidOperationException("Acting user is not authorized to manage staff for this schoolhouse.");
+            }
+        }
+
+        private async Task EnsureUserExists(Guid userId, CancellationToken ct)
+        {
+            var exists = await _dbContext.Users.AsNoTracking().AnyAsync(u => u.Id == userId, ct);
+            if (!exists)
+            {
+                throw new InvalidOperationException("User does not exist.");
+            }
+        }
+
+        private async Task EnsureInstructorProfileExists(Guid userId, CancellationToken ct)
+        {
+            var profileExists = await _dbContext.InstructorProfiles.AsNoTracking().AnyAsync(p => p.UserId == userId, ct);
+            if (!profileExists)
+            {
+                throw new InvalidOperationException("Instructor profile does not exist for the specified user.");
+            }
+        }
+
+        private async Task SetStaffRole(Guid schoolhouseId, Guid userId, StaffRole role, CancellationToken ct)
+        {
+            var staff = await _dbContext.SchoolhouseStaff.FirstOrDefaultAsync(s => s.SchoolhouseId == schoolhouseId && s.UserId == userId, ct);
+            var now = DateTime.UtcNow;
+            if (staff == null)
+            {
+                staff = new SchoolhouseStaff
+                {
+                    Id = Guid.NewGuid(),
+                    SchoolhouseId = schoolhouseId,
+                    UserId = userId,
+                    StaffRole = role,
+                    IsActive = true,
+                    CreatedAt = now
+                };
+                await _dbContext.SchoolhouseStaff.AddAsync(staff, ct);
+            }
+            else
+            {
+                staff.StaffRole = role;
+                staff.IsActive = true;
+                staff.UpdatedAt = now;
+            }
+
+            await _dbContext.SaveChangesAsync(ct);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add domain service interfaces for schoolhouse staff and media workflows
- implement staff service with role enforcement and instructor media cleanup
- implement media service for uploads and attachments across instructors, schoolhouses, and classes

## Testing
- `dotnet build` *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ffaf4bd68832ba67052ec2c2a21c2)