### PR TITLE
Add Swagger UI configuration for API testing

### DIFF
--- a/Azorian.csproj
+++ b/Azorian.csproj
@@ -8,13 +8,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.10">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Npgsql" Version="9.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.7" />
     </ItemGroup>
 
 </Project>

--- a/Controllers/index.cs
+++ b/Controllers/index.cs
@@ -3,7 +3,9 @@ using Microsoft.AspNetCore.Mvc;
 namespace Azorian.Controllers;
 
 [Route("/")]
-public class IndexController : Controller
+[ApiController]
+public class IndexController : ControllerBase
 {
-    public string Get() => "Hello World";
+    [HttpGet]
+    public ActionResult<string> Get() => "Hello World";
 }

--- a/Controllers/index.cs
+++ b/Controllers/index.cs
@@ -2,8 +2,10 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Azorian.Controllers;
 
+
 [Route("/")]
 public class IndexController : Controller
 {
+    [HttpGet]
     public string Get() => "Hello World";
 }

--- a/Migrations/AppDbContextModelSnapshot.cs
+++ b/Migrations/AppDbContextModelSnapshot.cs
@@ -22,6 +22,56 @@ namespace Azorian.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
+            modelBuilder.Entity("Azorian.Data.Class", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<DateTime?>("EndDateTimeUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<bool>("IsPublished")
+                        .HasColumnType("boolean");
+
+                    b.Property<decimal>("PricePerSeat")
+                        .HasColumnType("decimal(18,2)");
+
+                    b.Property<Guid>("SchoolhouseId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Slug")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<DateTime>("StartDateTimeUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Summary")
+                        .IsRequired()
+                        .HasMaxLength(2000)
+                        .HasColumnType("character varying(2000)");
+
+                    b.Property<string>("Title")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<DateTime?>("UpdatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("SchoolhouseId", "Slug")
+                        .IsUnique();
+
+                    b.ToTable("Classes");
+                });
+
             modelBuilder.Entity("Azorian.Data.ClassMedia", b =>
                 {
                     b.Property<Guid>("Id")
@@ -50,6 +100,8 @@ namespace Azorian.Migrations
                         .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("ClassId");
 
                     b.HasIndex("MediaAssetId");
 
@@ -429,13 +481,32 @@ namespace Azorian.Migrations
                     b.ToTable("Users");
                 });
 
+            modelBuilder.Entity("Azorian.Data.Class", b =>
+                {
+                    b.HasOne("Azorian.Data.Schoolhouse", "Schoolhouse")
+                        .WithMany("Classes")
+                        .HasForeignKey("SchoolhouseId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Schoolhouse");
+                });
+
             modelBuilder.Entity("Azorian.Data.ClassMedia", b =>
                 {
+                    b.HasOne("Azorian.Data.Class", "Class")
+                        .WithMany("Media")
+                        .HasForeignKey("ClassId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
                     b.HasOne("Azorian.Data.MediaAsset", "MediaAsset")
                         .WithMany("ClassMedia")
                         .HasForeignKey("MediaAssetId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+
+                    b.Navigation("Class");
 
                     b.Navigation("MediaAsset");
                 });
@@ -530,6 +601,11 @@ namespace Azorian.Migrations
                     b.Navigation("User");
                 });
 
+            modelBuilder.Entity("Azorian.Data.Class", b =>
+                {
+                    b.Navigation("Media");
+                });
+
             modelBuilder.Entity("Azorian.Data.InstructorProfile", b =>
                 {
                     b.Navigation("Media");
@@ -546,6 +622,8 @@ namespace Azorian.Migrations
 
             modelBuilder.Entity("Azorian.Data.Schoolhouse", b =>
                 {
+                    b.Navigation("Classes");
+
                     b.Navigation("Media");
 
                     b.Navigation("Staff");

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,6 @@
 using Azorian.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -8,7 +9,15 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "Azorian API",
+        Version = "v1"
+    });
+    options.CustomSchemaIds(type => type.FullName?.Replace('+', '.'));
+});
 
 builder.Services.AddDbContext<AppDbContext>(o =>
     o.UseNpgsql(builder.Configuration.GetConnectionString("Default")));

--- a/Program.cs
+++ b/Program.cs
@@ -7,18 +7,19 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
 
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
 builder.Services.AddDbContext<AppDbContext>(o =>
     o.UseNpgsql(builder.Configuration.GetConnectionString("Default")));
-
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-builder.Services.AddOpenApi();
 
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
-    app.MapOpenApi();
+    app.UseSwagger();
+    app.UseSwaggerUI();
 }
 
 app.UseHttpsRedirection();


### PR DESCRIPTION
## Summary
- add Swashbuckle.AspNetCore to provide Swagger generation support
- configure Swagger services and UI so the API can be exercised interactively in development

## Testing
- not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fff00d380832b87c806a621bab3bc)