### PR TITLE
Add current schoolhouse context service

### DIFF
--- a/Controllers/PublicSchoolhouseController.cs
+++ b/Controllers/PublicSchoolhouseController.cs
@@ -26,9 +26,14 @@ public class PublicSchoolhouseController : ControllerBase
     [HttpGet("index")]
     public async Task<ActionResult<PublicSchoolhouseIndexResponse>> GetIndex(CancellationToken cancellationToken)
     {
+        if (currentSchoolhouseContext.SchoolhouseId is not Guid schoolhouseId)
+        {
+            return NotFound();
+        }
+
         var schoolhouse = await dbContext.Schoolhouses
             .AsNoTracking()
-            .Where(s => s.Id == currentSchoolhouseContext.SchoolhouseId)
+            .Where(s => s.Id == schoolhouseId)
             .Select(s => new PublicSchoolhouseInfoDto(
                 s.Id,
                 s.Name,
@@ -122,9 +127,14 @@ public class PublicSchoolhouseController : ControllerBase
     [HttpGet("instructors")]
     public async Task<ActionResult<PublicSchoolhouseInstructorsResponse>> GetInstructors(CancellationToken cancellationToken)
     {
+        if (currentSchoolhouseContext.SchoolhouseId is not Guid schoolhouseId)
+        {
+            return NotFound();
+        }
+
         var schoolhouseExists = await dbContext.Schoolhouses
             .AsNoTracking()
-            .AnyAsync(s => s.Id == currentSchoolhouseContext.SchoolhouseId, cancellationToken);
+            .AnyAsync(s => s.Id == schoolhouseId, cancellationToken);
 
         if (!schoolhouseExists)
         {
@@ -133,7 +143,7 @@ public class PublicSchoolhouseController : ControllerBase
 
         var instructors = await dbContext.InstructorProfiles
             .AsNoTracking()
-            .Where(profile => dbContext.SchoolhouseStaff.Any(staff => staff.SchoolhouseId == currentSchoolhouseContext.SchoolhouseId && staff.StaffRole == StaffRole.Instructor && staff.IsActive && staff.UserId == profile.UserId))
+            .Where(profile => dbContext.SchoolhouseStaff.Any(staff => staff.SchoolhouseId == schoolhouseId && staff.StaffRole == StaffRole.Instructor && staff.IsActive && staff.UserId == profile.UserId))
             .Select(profile => new PublicInstructorDto(
                 profile.Id,
                 profile.DisplayName,
@@ -165,9 +175,14 @@ public class PublicSchoolhouseController : ControllerBase
     [HttpGet("classes")]
     public async Task<ActionResult<PublicSchoolhouseClassesResponse>> GetClasses([FromQuery] bool futureOnly, CancellationToken cancellationToken)
     {
+        if (currentSchoolhouseContext.SchoolhouseId is not Guid schoolhouseId)
+        {
+            return NotFound();
+        }
+
         var schoolhouseExists = await dbContext.Schoolhouses
             .AsNoTracking()
-            .AnyAsync(s => s.Id == currentSchoolhouseContext.SchoolhouseId, cancellationToken);
+            .AnyAsync(s => s.Id == schoolhouseId, cancellationToken);
 
         if (!schoolhouseExists)
         {
@@ -176,7 +191,7 @@ public class PublicSchoolhouseController : ControllerBase
 
         var query = dbContext.Classes
             .AsNoTracking()
-            .Where(c => c.SchoolhouseId == currentSchoolhouseContext.SchoolhouseId && c.IsPublished);
+            .Where(c => c.SchoolhouseId == schoolhouseId && c.IsPublished);
 
         if (futureOnly)
         {
@@ -202,9 +217,14 @@ public class PublicSchoolhouseController : ControllerBase
     [HttpGet("about")]
     public async Task<ActionResult<PublicSchoolhouseAboutResponse>> GetAbout(CancellationToken cancellationToken)
     {
+        if (currentSchoolhouseContext.SchoolhouseId is not Guid schoolhouseId)
+        {
+            return NotFound();
+        }
+
         var schoolhouse = await dbContext.Schoolhouses
             .AsNoTracking()
-            .Where(s => s.Id == currentSchoolhouseContext.SchoolhouseId)
+            .Where(s => s.Id == schoolhouseId)
             .Select(s => new { s.Id, s.LongDescription })
             .SingleOrDefaultAsync(cancellationToken);
 

--- a/Domain/Services/ICurrentSchoolhouseContext.cs
+++ b/Domain/Services/ICurrentSchoolhouseContext.cs
@@ -5,6 +5,6 @@ namespace Azorian.Domain.Services;
 
 public interface ICurrentSchoolhouseContext
 {
-    Guid SchoolhouseId { get; }
-    Schoolhouse Schoolhouse { get; }
+    Guid? SchoolhouseId { get; }
+    Schoolhouse? Schoolhouse { get; }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,6 @@
 using Azorian.Data;
+using Azorian.Domain.Services;
+using Azorian.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 
@@ -21,6 +23,9 @@ builder.Services.AddSwaggerGen(options =>
 
 builder.Services.AddDbContext<AppDbContext>(o =>
     o.UseNpgsql(builder.Configuration.GetConnectionString("Default")));
+
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddScoped<ICurrentSchoolhouseContext, CurrentSchoolhouseContext>();
 
 var app = builder.Build();
 

--- a/Services/CurrentSchoolhouseContext.cs
+++ b/Services/CurrentSchoolhouseContext.cs
@@ -19,11 +19,11 @@ public class CurrentSchoolhouseContext : ICurrentSchoolhouseContext
         _httpContextAccessor = httpContextAccessor;
     }
 
-    public Guid SchoolhouseId => Schoolhouse.Id;
+    public Guid? SchoolhouseId => Schoolhouse?.Id;
 
-    public Schoolhouse Schoolhouse => _schoolhouse ??= ResolveSchoolhouse();
+    public Schoolhouse? Schoolhouse => _schoolhouse ??= ResolveSchoolhouse();
 
-    private Schoolhouse ResolveSchoolhouse()
+    private Schoolhouse? ResolveSchoolhouse()
     {
         var slug = GetSchoolhouseSlugFromRequest();
 
@@ -38,13 +38,7 @@ public class CurrentSchoolhouseContext : ICurrentSchoolhouseContext
             }
         }
 
-        var schoolhouse = query.OrderBy(s => s.Name).FirstOrDefault();
-        if (schoolhouse == null)
-        {
-            throw new InvalidOperationException("No schoolhouse is configured.");
-        }
-
-        return schoolhouse;
+        return query.OrderBy(s => s.Name).FirstOrDefault();
     }
 
     private string? GetSchoolhouseSlugFromRequest()

--- a/Services/CurrentSchoolhouseContext.cs
+++ b/Services/CurrentSchoolhouseContext.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using Azorian.Data;
+using Azorian.Domain.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace Azorian.Services;
+
+public class CurrentSchoolhouseContext : ICurrentSchoolhouseContext
+{
+    private readonly AppDbContext _dbContext;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private Schoolhouse? _schoolhouse;
+
+    public CurrentSchoolhouseContext(AppDbContext dbContext, IHttpContextAccessor httpContextAccessor)
+    {
+        _dbContext = dbContext;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public Guid SchoolhouseId => Schoolhouse.Id;
+
+    public Schoolhouse Schoolhouse => _schoolhouse ??= ResolveSchoolhouse();
+
+    private Schoolhouse ResolveSchoolhouse()
+    {
+        var slug = GetSchoolhouseSlugFromRequest();
+
+        var query = _dbContext.Schoolhouses.AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(slug))
+        {
+            var schoolhouseBySlug = query.FirstOrDefault(s => s.Slug == slug);
+            if (schoolhouseBySlug != null)
+            {
+                return schoolhouseBySlug;
+            }
+        }
+
+        var schoolhouse = query.OrderBy(s => s.Name).FirstOrDefault();
+        if (schoolhouse == null)
+        {
+            throw new InvalidOperationException("No schoolhouse is configured.");
+        }
+
+        return schoolhouse;
+    }
+
+    private string? GetSchoolhouseSlugFromRequest()
+    {
+        var httpContext = _httpContextAccessor.HttpContext;
+        if (httpContext == null)
+        {
+            return null;
+        }
+
+        if (httpContext.Items.TryGetValue("CurrentSchoolhouseSlug", out var itemValue) && itemValue is string itemSlug && !string.IsNullOrWhiteSpace(itemSlug))
+        {
+            return itemSlug;
+        }
+
+        if (httpContext.Request.RouteValues.TryGetValue("schoolhouseSlug", out var routeValue) && routeValue is string routeSlug && !string.IsNullOrWhiteSpace(routeSlug))
+        {
+            return routeSlug;
+        }
+
+        if (httpContext.Request.Query.TryGetValue("schoolhouseSlug", out var querySlug) && !string.IsNullOrWhiteSpace(querySlug))
+        {
+            return querySlug.ToString();
+        }
+
+        if (httpContext.Request.Headers.TryGetValue("X-Schoolhouse-Slug", out var headerSlug) && !string.IsNullOrWhiteSpace(headerSlug))
+        {
+            return headerSlug.ToString();
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- add an implementation of `ICurrentSchoolhouseContext` that resolves the active schoolhouse based on the incoming request
- register the new context service and `IHttpContextAccessor` with the dependency injection container so controllers can consume it

## Testing
- dotnet build *(fails: `dotnet` command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691004ffc17c832b8466e91586b75823)