### PR TITLE
Add CRUD endpoints for managing schoolhouses

### DIFF
--- a/Controllers/SchoolhouseController.cs
+++ b/Controllers/SchoolhouseController.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azorian.Data;
+using Azorian.Domain.DTOs;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Azorian.Controllers;
+
+[ApiController]
+[Route("schoolhouses")]
+public class SchoolhouseController : ControllerBase
+{
+    private readonly AppDbContext dbContext;
+
+    public SchoolhouseController(AppDbContext dbContext)
+    {
+        this.dbContext = dbContext;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<SchoolhouseSummaryDto[]>> Browse(CancellationToken cancellationToken)
+    {
+        var schoolhouses = await dbContext.Schoolhouses
+            .AsNoTracking()
+            .OrderBy(s => s.Name)
+            .Select(s => new SchoolhouseSummaryDto(
+                s.Id,
+                s.Name,
+                s.Slug,
+                s.IsPublished))
+            .ToArrayAsync(cancellationToken);
+
+        return Ok(schoolhouses);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<SchoolhouseDetailDto>> Read(Guid id, CancellationToken cancellationToken)
+    {
+        var schoolhouse = await dbContext.Schoolhouses
+            .AsNoTracking()
+            .Where(s => s.Id == id)
+            .Select(s => new SchoolhouseDetailDto(
+                s.Id,
+                s.Name,
+                s.Slug,
+                s.Subdomain,
+                s.Tagline,
+                s.ShortDescription,
+                s.LongDescription,
+                s.LogoUrl,
+                s.HeroImageUrl,
+                s.ContactEmail,
+                s.ContactPhone,
+                s.AddressLine1,
+                s.AddressLine2,
+                s.City,
+                s.State,
+                s.PostalCode,
+                s.Country,
+                s.IsPublished,
+                s.CreatedByUserId,
+                s.CreatedAt,
+                s.UpdatedAt))
+            .SingleOrDefaultAsync(cancellationToken);
+
+        if (schoolhouse is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(schoolhouse);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<SchoolhouseDetailDto>> Add(
+        [FromBody] SchoolhouseCreateRequest request,
+        CancellationToken cancellationToken)
+    {
+        var schoolhouse = new Schoolhouse
+        {
+            Id = Guid.NewGuid(),
+            Name = request.Name,
+            Slug = request.Slug,
+            Subdomain = request.Subdomain,
+            Tagline = request.Tagline,
+            ShortDescription = request.ShortDescription,
+            LongDescription = request.LongDescription,
+            LogoUrl = request.LogoUrl,
+            HeroImageUrl = request.HeroImageUrl,
+            ContactEmail = request.ContactEmail,
+            ContactPhone = request.ContactPhone,
+            AddressLine1 = request.AddressLine1,
+            AddressLine2 = request.AddressLine2,
+            City = request.City,
+            State = request.State,
+            PostalCode = request.PostalCode,
+            Country = request.Country,
+            IsPublished = request.IsPublished,
+            CreatedByUserId = request.CreatedByUserId,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        dbContext.Schoolhouses.Add(schoolhouse);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        var response = await ProjectToDetail(schoolhouse.Id, cancellationToken);
+        return CreatedAtAction(nameof(Read), new { id = schoolhouse.Id }, response);
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<ActionResult<SchoolhouseDetailDto>> Edit(
+        Guid id,
+        [FromBody] SchoolhouseUpdateRequest request,
+        CancellationToken cancellationToken)
+    {
+        var schoolhouse = await dbContext.Schoolhouses
+            .SingleOrDefaultAsync(s => s.Id == id, cancellationToken);
+
+        if (schoolhouse is null)
+        {
+            return NotFound();
+        }
+
+        schoolhouse.Name = request.Name;
+        schoolhouse.Slug = request.Slug;
+        schoolhouse.Subdomain = request.Subdomain;
+        schoolhouse.Tagline = request.Tagline;
+        schoolhouse.ShortDescription = request.ShortDescription;
+        schoolhouse.LongDescription = request.LongDescription;
+        schoolhouse.LogoUrl = request.LogoUrl;
+        schoolhouse.HeroImageUrl = request.HeroImageUrl;
+        schoolhouse.ContactEmail = request.ContactEmail;
+        schoolhouse.ContactPhone = request.ContactPhone;
+        schoolhouse.AddressLine1 = request.AddressLine1;
+        schoolhouse.AddressLine2 = request.AddressLine2;
+        schoolhouse.City = request.City;
+        schoolhouse.State = request.State;
+        schoolhouse.PostalCode = request.PostalCode;
+        schoolhouse.Country = request.Country;
+        schoolhouse.IsPublished = request.IsPublished;
+        schoolhouse.UpdatedAt = DateTime.UtcNow;
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        var response = await ProjectToDetail(id, cancellationToken);
+        return Ok(response);
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
+    {
+        var schoolhouse = await dbContext.Schoolhouses
+            .SingleOrDefaultAsync(s => s.Id == id, cancellationToken);
+
+        if (schoolhouse is null)
+        {
+            return NotFound();
+        }
+
+        dbContext.Schoolhouses.Remove(schoolhouse);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return NoContent();
+    }
+
+    private async Task<SchoolhouseDetailDto> ProjectToDetail(Guid id, CancellationToken cancellationToken)
+    {
+        return await dbContext.Schoolhouses
+            .AsNoTracking()
+            .Where(s => s.Id == id)
+            .Select(s => new SchoolhouseDetailDto(
+                s.Id,
+                s.Name,
+                s.Slug,
+                s.Subdomain,
+                s.Tagline,
+                s.ShortDescription,
+                s.LongDescription,
+                s.LogoUrl,
+                s.HeroImageUrl,
+                s.ContactEmail,
+                s.ContactPhone,
+                s.AddressLine1,
+                s.AddressLine2,
+                s.City,
+                s.State,
+                s.PostalCode,
+                s.Country,
+                s.IsPublished,
+                s.CreatedByUserId,
+                s.CreatedAt,
+                s.UpdatedAt))
+            .SingleAsync(cancellationToken);
+    }
+}

--- a/Domain/DTOs/SchoolhouseDtos.cs
+++ b/Domain/DTOs/SchoolhouseDtos.cs
@@ -1,0 +1,72 @@
+using System;
+
+namespace Azorian.Domain.DTOs
+{
+    public record SchoolhouseSummaryDto(
+        Guid Id,
+        string Name,
+        string Slug,
+        bool IsPublished);
+
+    public record SchoolhouseDetailDto(
+        Guid Id,
+        string Name,
+        string Slug,
+        string Subdomain,
+        string Tagline,
+        string ShortDescription,
+        string LongDescription,
+        string LogoUrl,
+        string HeroImageUrl,
+        string ContactEmail,
+        string ContactPhone,
+        string AddressLine1,
+        string AddressLine2,
+        string City,
+        string State,
+        string PostalCode,
+        string Country,
+        bool IsPublished,
+        Guid CreatedByUserId,
+        DateTime CreatedAt,
+        DateTime? UpdatedAt);
+
+    public record SchoolhouseCreateRequest(
+        string Name,
+        string Slug,
+        string Subdomain,
+        string Tagline,
+        string ShortDescription,
+        string LongDescription,
+        string LogoUrl,
+        string HeroImageUrl,
+        string ContactEmail,
+        string ContactPhone,
+        string AddressLine1,
+        string AddressLine2,
+        string City,
+        string State,
+        string PostalCode,
+        string Country,
+        bool IsPublished,
+        Guid CreatedByUserId);
+
+    public record SchoolhouseUpdateRequest(
+        string Name,
+        string Slug,
+        string Subdomain,
+        string Tagline,
+        string ShortDescription,
+        string LongDescription,
+        string LogoUrl,
+        string HeroImageUrl,
+        string ContactEmail,
+        string ContactPhone,
+        string AddressLine1,
+        string AddressLine2,
+        string City,
+        string State,
+        string PostalCode,
+        string Country,
+        bool IsPublished);
+}

--- a/docs/ENDPOINTS_BREAD.md
+++ b/docs/ENDPOINTS_BREAD.md
@@ -1,0 +1,42 @@
+# Endpoint BREAD Overview
+
+This document categorizes each HTTP endpoint exposed by the Azorian API according to the BREAD (Browse, Read, Edit, Add, Delete)
+actions it supports.
+
+## PublicSchoolhouseController (`/public`)
+
+| Route | Verb | BREAD Action | Description |
+| --- | --- | --- | --- |
+| `/public/index` | GET | Browse | Returns the full public overview for the current schoolhouse, including profile, media assets, instructor list, and upcoming classes. |
+| `/public/instructors` | GET | Browse | Lists the public instructor profiles associated with the current schoolhouse. |
+| `/public/classes` | GET | Browse | Lists published classes for the current schoolhouse. Supports the optional `futureOnly=true` query to limit the result set to upcoming classes. |
+| `/public/about` | GET | Read | Returns the long-form description and public media for the current schoolhouse. |
+
+> **Note:** The public endpoints provide read-only access. Edit/Add/Delete actions are intentionally not exposed in this controller.
+
+## SchoolhouseController (`/schoolhouses`)
+
+| Route | Verb | BREAD Action | Description |
+| --- | --- | --- | --- |
+| `/schoolhouses` | GET | Browse | Returns the list of schoolhouses with summary information suitable for administration screens. |
+| `/schoolhouses/{id}` | GET | Read | Returns the full editable details for a single schoolhouse record. |
+| `/schoolhouses` | POST | Add | Creates a new schoolhouse record and returns the populated resource. |
+| `/schoolhouses/{id}` | PUT | Edit | Updates an existing schoolhouse record with the supplied fields. |
+| `/schoolhouses/{id}` | DELETE | Delete | Removes a schoolhouse record. Related data follows the configured EF Core cascade rules. |
+
+## IndexController (`/`)
+
+| Route | Verb | BREAD Action | Description |
+| --- | --- | --- | --- |
+| `/` | GET | Read | Returns a static "Hello World" payload for service health verification. |
+
+## Summary of Supported BREAD Actions
+
+- **Browse**: `/public/index`, `/public/instructors`, `/public/classes`, `/schoolhouses`
+- **Read**: `/public/about`, `/`, `/schoolhouses/{id}`
+- **Edit**: `/schoolhouses/{id}`
+- **Add**: `/schoolhouses`
+- **Delete**: `/schoolhouses/{id}`
+
+The `SchoolhouseController` introduces full management capabilities for schoolhouse records. Access to these endpoints should be protected
+with appropriate authentication and authorization in production environments.


### PR DESCRIPTION
## Summary
- introduce a dedicated `SchoolhouseController` that exposes browse/read/edit/add/delete endpoints for schoolhouses
- add DTOs for schoolhouse administration payloads
- update the endpoint documentation to cover the new management surface

## Testing
- dotnet build *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69100803562c832ba296d2aa7d50725f)